### PR TITLE
修复一些辅助脚本的bug；增加resume训练的选项

### DIFF
--- a/bert_gen.py
+++ b/bert_gen.py
@@ -39,8 +39,14 @@ def process_line(line):
         assert bert.shape[-1] == len(phone)
         torch.save(bert, bert_path)
 
-with open(hps.data.training_files, encoding='utf-8') as f:
-    lines = f.readlines()
+
+lines = []
+with open(hps.data.training_files) as f:
+    lines.extend(f.readlines())
+
+with open(hps.data.validation_files) as f:
+    lines.extend(f.readlines())
+
 
 with Pool(processes=12) as pool: #A100 suitable config,if coom,please decrease the processess number.
     for _ in tqdm(pool.imap_unordered(process_line, lines)):

--- a/resample.py
+++ b/resample.py
@@ -14,10 +14,10 @@ def process(item):
     speaker = spkdir.replace("\\", "/").split("/")[-1]
     wav_path = os.path.join(args.in_dir, speaker, wav_name)
     if os.path.exists(wav_path) and '.wav' in wav_path:
-        os.makedirs(os.path.join(args.out_dir2, speaker), exist_ok=True)
-        wav, sr = librosa.load(wav_path, sr=args.sr2)
+        os.makedirs(os.path.join(args.out_dir, speaker), exist_ok=True)
+        wav, sr = librosa.load(wav_path, sr=args.sr)
         soundfile.write(
-            os.path.join(args.out_dir2, speaker, wav_name),
+            os.path.join(args.out_dir, speaker, wav_name),
             wav,
             sr
         )

--- a/train_ms.py
+++ b/train_ms.py
@@ -155,11 +155,11 @@ def run(rank, n_gpus, hps):
     if pretrain_dir is None:
         try:
             if net_dur_disc is not None:
-                _, _, _, epoch_str = utils.load_checkpoint(utils.latest_checkpoint_path(hps.model_dir, "DUR_*.pth"), net_dur_disc, optim_dur_disc, skip_optimizer=True)
-            _, _, _, epoch_str = utils.load_checkpoint(utils.latest_checkpoint_path(hps.model_dir, "G_*.pth"), net_g,
-                                                   optim_g, skip_optimizer=True)
-            _, _, _, epoch_str = utils.load_checkpoint(utils.latest_checkpoint_path(hps.model_dir, "D_*.pth"), net_d,
-                                                   optim_d, skip_optimizer=True)
+                _, optim_dur_disc, _, epoch_str = utils.load_checkpoint(utils.latest_checkpoint_path(hps.model_dir, "DUR_*.pth"), net_dur_disc, optim_dur_disc, skip_optimizer=not hps.resume)
+            _, optim_g, _, epoch_str = utils.load_checkpoint(utils.latest_checkpoint_path(hps.model_dir, "G_*.pth"), net_g,
+                                                   optim_g, skip_optimizer=not hps.resume)
+            _, optim_d, _, epoch_str = utils.load_checkpoint(utils.latest_checkpoint_path(hps.model_dir, "D_*.pth"), net_d,
+                                                   optim_d, skip_optimizer=not hps.resume)
             
             epoch_str = max(epoch_str, 1)
             global_step = (epoch_str - 1) * len(train_loader)

--- a/utils.py
+++ b/utils.py
@@ -158,6 +158,7 @@ def get_hparams(init=True):
                         help='JSON file for configuration')
     parser.add_argument('-m', '--model', type=str, required=True,
                         help='Model name')
+    parser.add_argument('--resume', dest='resume', action="store_true", default=False, help="resume training from latest checkpoint of the given model")
 
     args = parser.parse_args()
     model_dir = os.path.join("./logs", args.model)
@@ -179,6 +180,7 @@ def get_hparams(init=True):
 
     hparams = HParams(**config)
     hparams.model_dir = model_dir
+    hparams.resume = args.resume
     return hparams
 
 


### PR DESCRIPTION
修改记录：

- 修复了`bert_gen.py`中只为`training_files`生成`.bert.pt`文件的问题，现在它也会为`validation_files`生成文件。
- 修复了`resample.py`中使用不存在的变量`args.out_dir2`和`args.sr2`的问题。
- 考虑微调开始一段时间后因为各种原因中断训练的情况。如果再使用同样的命令进行训练，会报如下错误（行数可能与实际行数有出入）：
  ```
  -- Process 0 terminated with the following error:
  Traceback (most recent call last):
    File "/home/_/.local/lib/python3.10/site-packages/torch/multiprocessing/spawn.py", line 69, in _wrap
      fn(i, *args)
    File "/home/_/projects/tts/Bert-VITS2/train_ms.py", line 180, in run
      scheduler_g = torch.optim.lr_scheduler.ExponentialLR(optim_g, gamma=hps.train.lr_decay, last_epoch=epoch_str - 2)
    File "/home/_/.local/lib/python3.10/site-packages/torch/optim/lr_scheduler.py", line 591, in __init__
      super().__init__(optimizer, last_epoch, verbose)
    File "/home/_/.local/lib/python3.10/site-packages/torch/optim/lr_scheduler.py", line 43, in __init__
      raise KeyError("param 'initial_lr' is not specified "
  KeyError: "param 'initial_lr' is not specified in param_groups[0] when resuming an optimizer"
  ```
  这应该是因为`train_ms.py`中读取模型时，`utils.load_checkpoint`默认将`skip_optimizer`设为`True`。因此在训练中断后，再次使用同一命令继续训练时，optimizer的数据会因此丢失，进而导致scheduler无法正常初始化。
  因此，我增加了`--resume`选项来控制`skip_optimizer`的值。在本地测试中成功做到了继续训练。

我对仓库的理解仅止于表面，这些改动不一定是正确的做法。如果有错误恳请指正，感谢。